### PR TITLE
Add DB configuration

### DIFF
--- a/Panorama.API/Models/DatabaseSettings.cs
+++ b/Panorama.API/Models/DatabaseSettings.cs
@@ -1,0 +1,11 @@
+namespace Panorama.API.Models;
+
+public class DatabaseSettings
+{
+    public string? ConnectionString { get; set; }
+    public string? Host { get; set; }
+    public int Port { get; set; }
+    public string? Database { get; set; }
+    public string? User { get; set; }
+    public string? Password { get; set; }
+}

--- a/Panorama.API/Program.cs
+++ b/Panorama.API/Program.cs
@@ -1,4 +1,5 @@
 using Panorama.API.Services;
+using Panorama.API.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -7,6 +8,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllers();
+
+builder.Services.Configure<DatabaseSettings>(builder.Configuration.GetSection("Database"));
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/Panorama.API/appsettings.json
+++ b/Panorama.API/appsettings.json
@@ -5,5 +5,13 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Database": {
+    "ConnectionString": "postgresql://postgres:[YOUR-PASSWORD]@db.mnkupvkwdsfszvytucst.supabase.co:5432/postgres",
+    "Host": "db.mnkupvkwdsfszvytucst.supabase.co",
+    "Port": 5432,
+    "Database": "postgres",
+    "User": "postgres",
+    "Password": "[YOUR-PASSWORD]"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # PanoramaPOC
-POC 
+POC
+
+## Configuracion de base de datos
+
+El proyecto utiliza un bloque `Database` en `appsettings.json` para definir la
+conexion a PostgreSQL. Estos valores pueden sobrescribirse mediante variables de
+entorno con el prefijo `Database__`.
+
+Ejemplo de configuracion de produccion:
+
+```json
+"Database": {
+  "ConnectionString": "postgresql://postgres:[YOUR-PASSWORD]@db.mnkupvkwdsfszvytucst.supabase.co:5432/postgres",
+  "Host": "db.mnkupvkwdsfszvytucst.supabase.co",
+  "Port": 5432,
+  "Database": "postgres",
+  "User": "postgres",
+  "Password": "[YOUR-PASSWORD]"
+}
+```
+
+Para configurarlo mediante variables de entorno, defina por ejemplo:
+
+```bash
+export Database__Password=mi_password
+```
+
+De esta manera la configuracion es facilmente modificable segun el entorno.


### PR DESCRIPTION
## Summary
- make DB credentials configurable via `Database` section
- register new `DatabaseSettings` model
- document DB configuration in README

## Testing
- `dotnet build PanoramaPOC.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a0b8fa2988327b3bd2eb0153b8e28